### PR TITLE
Added initial version of OPC UA ontology

### DIFF
--- a/OPC UA/OpcUa.owl
+++ b/OPC UA/OpcUa.owl
@@ -1,0 +1,9663 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.fortiss.org/kb/opcua/OpcUaNodeSet2.owl#"
+     xml:base="http://www.fortiss.org/kb/opcua/OpcUaNodeSet2.owl"
+     xmlns:ua="http://www.fortiss.org/kb/opcua/OpcUaNodeSet2.owl#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:ua-core="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#"
+     xmlns:OpcUaNodeSet2="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#">
+    <owl:Ontology rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl">
+        <owl:imports rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl/0.1.0"/>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#objectProperty -->
+
+    <owl:AnnotationProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#objectProperty"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#referenceType -->
+
+    <owl:AnnotationProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#referenceType"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#containsNode -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#containsNode"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#firstValue -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#firstValue"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasDataType -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasDataType"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasDataTypeDefinition -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasDataTypeDefinition"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasDataTypeField -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasDataTypeField"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasExtType -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasExtType"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasMethodDeclaration -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasMethodDeclaration"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasParent -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasParent"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasValue -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#hasValue"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#nextValue -->
+
+    <owl:ObjectProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#nextValue"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregatedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregatedBy">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasChild"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Aggregates"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alarmGroupMember -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alarmGroupMember">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizes"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#memberOfAlarmGroup"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupMember"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alwaysGeneratedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alwaysGeneratedBy">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alwaysGeneratesEvent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alwaysGeneratesEvent -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alwaysGeneratesEvent">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatesEvent"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlwaysGeneratesEvent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#childOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#childOf">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasChild"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#componentOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#componentOf">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#dataSetToWriter -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#dataSetToWriter">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#writerToDataSet"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetToWriter"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#descriptionOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#descriptionOf">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDescription"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#encodingOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#encodingOf">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEncoding"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#eventSourceOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#eventSourceOf">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEventSource"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#fromState -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#fromState">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toTransition"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FromState"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#fromTransition -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#fromTransition">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toState"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatedBy">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatesEvent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatesEvent -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatesEvent">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneratesEvent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasAlarmSuppressionGroup -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasAlarmSuppressionGroup">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isAlarmSuppressionGroupOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasAlarmSuppressionGroup"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasCause -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasCause">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeCausedBy"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCause"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasChild -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasChild">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasChild"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasComponent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasCondition -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasCondition">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isConditionOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCondition"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDataSetReader -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDataSetReader">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isReaderInGroup"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetReader"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDataSetWriter -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDataSetWriter">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isWriterInGroup"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetWriter"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDescription -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDescription">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDescription"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeEffectedBy"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffect"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectDisable -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectDisable">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeDisabledBy"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectDisable"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectEnable -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectEnable">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeEnabledBy"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectEnable"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectSuppressed -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectSuppressed">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeSuppressedBy"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectSuppressed"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectUnsuppressed -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectUnsuppressed">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeUnsuppressedBy"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectUnsuppressed"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEncoding -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEncoding">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEncoding"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEventSource -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEventSource">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEventSource"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasFalseSubState -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasFalseSubState">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isFalseSubStateOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasFalseSubState"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasHistoricalConfiguration -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasHistoricalConfiguration">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#historicalConfigurationOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasHistoricalConfiguration"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasModellingRule -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasModellingRule">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#modellingRuleOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasModellingRule"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasNotifier -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasNotifier">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEventSource"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#notifierOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasNotifier"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasOrderedComponent -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasOrderedComponent">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#orderedComponentOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasOrderedComponent"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasProperty -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasProperty">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#propertyOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasPubSubConnection -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasPubSubConnection">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#pubSubConnectionOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasPubSubConnection"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasSubStateMachine -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasSubStateMachine">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#subStateMachineOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubStateMachine"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasSubtype -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasSubtype">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasChild"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#subtypeOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubtype"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasTrueSubState -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasTrueSubState">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isTrueSubStateOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTrueSubState"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasTypeDefinition -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasTypeDefinition">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#typeDefinitionOf"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTypeDefinition"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#references"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HierarchicalReferences"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#historicalConfigurationOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#historicalConfigurationOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isAlarmSuppressionGroupOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isAlarmSuppressionGroupOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isConditionOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isConditionOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isFalseSubStateOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isFalseSubStateOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isReaderInGroup -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isReaderInGroup"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isTrueSubStateOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isTrueSubStateOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isWriterInGroup -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#isWriterInGroup"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeCausedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeCausedBy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeDisabledBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeDisabledBy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeEffectedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeEffectedBy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeEnabledBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeEnabledBy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeSuppressedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeSuppressedBy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeUnsuppressedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#mayBeUnsuppressedBy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#memberOfAlarmGroup -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#memberOfAlarmGroup"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#modellingRuleOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#modellingRuleOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#references"/>
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonHierarchicalReferences"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#notifierOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#notifierOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#orderedComponentOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#orderedComponentOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizedBy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizedBy">
+        <owl:inverseOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizes"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizes -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizes">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Organizes"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#propertyOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#propertyOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#pubSubConnectionOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#pubSubConnectionOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#references -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#references">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#References"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#subStateMachineOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#subStateMachineOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#subtypeOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#subtypeOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toState -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toState">
+        <rdfs:subPropertyOf rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+        <ua-core:referenceType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ToState"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toTransition -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toTransition"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#typeDefinitionOf -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#typeDefinitionOf"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#writerToDataSet -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#writerToDataSet"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#hasMessageSecurityMode -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#hasMessageSecurityMode">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+        <rdfs:range rdf:resource="http://www.hsu-ifa.de/ontologies/OpcUa.owl#MessageSecurityMode"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#hasSecurityPolicy -->
+
+    <owl:ObjectProperty rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#hasSecurityPolicy">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#accessLevel -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#accessLevel"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#accessRestrictions -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#accessRestrictions"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#argumentName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#argumentName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#arrayDimensions -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#arrayDimensions"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#browseName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#browseName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#browseNamespace -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#browseNamespace"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#definitionName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#definitionName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#description -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#description"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#displayName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#displayName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#eventNotifier -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#eventNotifier"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#executable -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#executable"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#fieldName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#fieldName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#historizing -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#historizing"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#inverseName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#inverseName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isAbstract -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isAbstract"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isOptionSet -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isOptionSet"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isOptional -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isOptional"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isUnion -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#isUnion"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#lastModified -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#lastModified"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#minimumSamplingInterval -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#minimumSamplingInterval"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#modelUri -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#modelUri"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#nodeId -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#nodeId"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#nodeNamespace -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#nodeNamespace"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#numberOfValues -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#numberOfValues"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#symbolicName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#symbolicName"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#symmetric -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#symmetric"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#userAccessLevel -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#userAccessLevel"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#userExecutable -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#userExecutable"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#value -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#value"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#valueRank -->
+
+    <owl:DatatypeProperty rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#valueRank"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#hasEndpointUrl -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#hasEndpointUrl">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#requiresPassword -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#requiresPassword">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#requiresUserName -->
+
+    <owl:DatatypeProperty rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#requiresUserName">
+        <rdfs:domain rdf:resource="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataTypeDefinition -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataTypeDefinition"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataTypeField -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataTypeField"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAMethod -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAMethod"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UANodeSet -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UANodeSet"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObject -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObject"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAValue -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAValue"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariable -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariable"/>
+    
+
+
+    <!-- http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType -->
+
+    <owl:Class rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#MessageSecurityMode -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#MessageSecurityMode"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#SecurityPolicy -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#SecurityPolicy"/>
+    
+
+
+    <!-- http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer -->
+
+    <owl:Class rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelExType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelExType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AccessLevelExType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AccessLevelExType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15406</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AccessLevelType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AccessLevelType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15031</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessRestrictionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessRestrictionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AccessRestrictionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AccessRestrictionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=95</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AcknowledgeableConditionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AcknowledgeableConditionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmConditionType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AcknowledgeableConditionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AcknowledgeableConditionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2881</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddNodesItem -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddNodesItem">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AddNodesItem</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A request to add a node to the server address space.</ua-core:description>
+        <ua-core:displayName>AddNodesItem</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=376</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddReferencesItem -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddReferencesItem">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AddReferencesItem</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A request to add a reference to the server address space.</ua-core:description>
+        <ua-core:displayName>AddReferencesItem</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=379</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddressSpaceFileType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddressSpaceFileType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AddressSpaceFileType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A file used to store a namespace exported from the server.</ua-core:description>
+        <ua-core:displayName>AddressSpaceFileType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11595</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfiguration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfiguration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AggregateConfiguration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AggregateConfiguration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=948</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfigurationType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfigurationType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AggregateConfigurationType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AggregateConfigurationType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11187</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateFunctionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateFunctionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AggregateFunctionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AggregateFunctionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2340</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Aggregates -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Aggregates">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasComponent"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasHistoricalConfiguration"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasProperty"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Aggregates</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical references that are used to aggregate nodes into complex types.</ua-core:description>
+        <ua-core:displayName>Aggregates</ua-core:displayName>
+        <ua-core:inverseName>AggregatedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=44</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#aggregates"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmConditionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmConditionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscrepancyAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LimitAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AlarmConditionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AlarmConditionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2915</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupMember -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupMember">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AlarmGroupMember</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AlarmGroupMember</ua-core:displayName>
+        <ua-core:inverseName>MemberOfAlarmGroup</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=16362</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alarmGroupMember"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AlarmGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AlarmGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=16405</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmMetricsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmMetricsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AlarmMetricsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AlarmMetricsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17279</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmRateVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmRateVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Double"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AlarmRateVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AlarmRateVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17277</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlwaysGeneratesEvent -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlwaysGeneratesEvent">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AlwaysGeneratesEvent</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for references from a node to an event type that is always raised by node.</ua-core:description>
+        <ua-core:displayName>AlwaysGeneratesEvent</ua-core:displayName>
+        <ua-core:inverseName>AlwaysGeneratedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=3065</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#alwaysGeneratesEvent"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnalogItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnalogItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Number"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AnalogItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AnalogItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2368</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Annotation -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Annotation">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Annotation</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>Annotation</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=891</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnonymousIdentityToken -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnonymousIdentityToken">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AnonymousIdentityToken</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A token representing an anonymous user.</ua-core:description>
+        <ua-core:displayName>AnonymousIdentityToken</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=319</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationCertificateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationCertificateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaMinApplicationCertificateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaSha256ApplicationCertificateType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ApplicationCertificateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ApplicationCertificateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=12557</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ApplicationDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes an application and how to find it.</ua-core:description>
+        <ua-core:displayName>ApplicationDescription</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=308</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationInstanceCertificate -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationInstanceCertificate">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ApplicationInstanceCertificate</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A certificate for an instance of an application.</ua-core:description>
+        <ua-core:displayName>ApplicationInstanceCertificate</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=311</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ApplicationType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The types of applications.</ua-core:description>
+        <ua-core:displayName>ApplicationType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=307</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Argument -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Argument">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Argument</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An argument for a method.</ua-core:description>
+        <ua-core:displayName>Argument</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=296</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ArrayItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ArrayItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CubeItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NDimensionArrayItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XYArrayItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#YArrayItemType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ArrayItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ArrayItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=12021</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeOperand -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeOperand">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AttributeOperand</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AttributeOperand</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=598</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeWriteMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeWriteMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AttributeWriteMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Define bits used to indicate which attributes are writable.</ua-core:description>
+        <ua-core:displayName>AttributeWriteMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=347</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AudioDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An image encoded in PNG format.</ua-core:description>
+        <ua-core:displayName>AudioDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=16307</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AudioVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AudioVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17986</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditActivateSessionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditActivateSessionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditActivateSessionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditActivateSessionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2075</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddNodesEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddNodesEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditAddNodesEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditAddNodesEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2091</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddReferencesEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddReferencesEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditAddReferencesEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditAddReferencesEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2095</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCancelEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCancelEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCancelEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCancelEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2078</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateDataMismatchEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateDataMismatchEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateDataMismatchEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateDataMismatchEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2082</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateDataMismatchEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateExpiredEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateInvalidEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateMismatchEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateRevokedEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateUntrustedEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2080</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateExpiredEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateExpiredEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateExpiredEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateExpiredEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2085</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateInvalidEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateInvalidEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateInvalidEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateInvalidEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2086</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateMismatchEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateMismatchEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateMismatchEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateMismatchEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2089</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateRevokedEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateRevokedEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateRevokedEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateRevokedEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2088</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateUntrustedEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateUntrustedEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCertificateUntrustedEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditCertificateUntrustedEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2087</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditChannelEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditChannelEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditOpenSecureChannelEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditChannelEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for events used to track related changes to a secure channel.</ua-core:description>
+        <ua-core:displayName>AuditChannelEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2059</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionAcknowledgeEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionAcknowledgeEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionAcknowledgeEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionAcknowledgeEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=8944</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionCommentEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionCommentEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionCommentEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionCommentEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2829</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionConfirmEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionConfirmEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionConfirmEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionConfirmEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=8961</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEnableEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEnableEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionEnableEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionEnableEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2803</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionAcknowledgeEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionCommentEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionConfirmEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEnableEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionOutOfServiceEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionResetEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionRespondEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionShelvingEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSilenceEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSuppressEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2790</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionOutOfServiceEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionOutOfServiceEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionOutOfServiceEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionOutOfServiceEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17259</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionResetEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionResetEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionResetEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionResetEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15013</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionRespondEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionRespondEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionRespondEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionRespondEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=8927</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionShelvingEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionShelvingEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionShelvingEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionShelvingEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11093</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSilenceEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSilenceEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionSilenceEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionSilenceEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17242</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSuppressEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSuppressEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditConditionSuppressEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditConditionSuppressEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17225</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCreateSessionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCreateSessionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUrlMismatchEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditCreateSessionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An event that is raised when a session is created.</ua-core:description>
+        <ua-core:displayName>AuditCreateSessionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2071</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteNodesEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteNodesEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditDeleteNodesEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditDeleteNodesEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2093</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteReferencesEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteReferencesEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditDeleteReferencesEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditDeleteReferencesEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2097</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditNodeManagementEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSecurityEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateMethodEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for events used to track client initiated changes to the server state.</ua-core:description>
+        <ua-core:displayName>AuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2052</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryAtTimeDeleteEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryAtTimeDeleteEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryAtTimeDeleteEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryAtTimeDeleteEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=3019</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryDeleteEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryDeleteEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryAtTimeDeleteEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventDeleteEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryRawModifyDeleteEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryDeleteEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryDeleteEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=3012</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventDeleteEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventDeleteEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryEventDeleteEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryEventDeleteEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=3022</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventUpdateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventUpdateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryEventUpdateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryEventUpdateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2999</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryRawModifyDeleteEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryRawModifyDeleteEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryRawModifyDeleteEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryRawModifyDeleteEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=3014</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryUpdateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryUpdateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryDeleteEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventUpdateEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryValueUpdateEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryUpdateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryUpdateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2104</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryValueUpdateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryValueUpdateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditHistoryValueUpdateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditHistoryValueUpdateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=3006</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditNodeManagementEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditNodeManagementEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddNodesEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddReferencesEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteNodesEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteReferencesEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditNodeManagementEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditNodeManagementEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2090</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditOpenSecureChannelEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditOpenSecureChannelEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditOpenSecureChannelEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An event that is raised when a secure channel is opened.</ua-core:description>
+        <ua-core:displayName>AuditOpenSecureChannelEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2060</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditProgramTransitionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditProgramTransitionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditProgramTransitionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditProgramTransitionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11856</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSecurityEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSecurityEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditChannelEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSessionEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditSecurityEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for events used to track security related changes.</ua-core:description>
+        <ua-core:displayName>AuditSecurityEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2058</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSessionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSessionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditActivateSessionEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCancelEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCreateSessionEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditSessionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for events used to track related changes to a session.</ua-core:description>
+        <ua-core:displayName>AuditSessionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2069</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryUpdateEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditWriteUpdateEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditUpdateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditUpdateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2099</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateMethodEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateMethodEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateStateEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateUpdatedAuditEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialAuditEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleMappingRuleChangedAuditEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListUpdatedAuditEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditUpdateMethodEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditUpdateMethodEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2127</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateStateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateStateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditProgramTransitionEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionAuditEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditUpdateStateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditUpdateStateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2315</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUrlMismatchEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUrlMismatchEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditUrlMismatchEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditUrlMismatchEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2748</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditWriteUpdateEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditWriteUpdateEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuditWriteUpdateEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuditWriteUpdateEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2100</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuthorizationServiceConfigurationType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuthorizationServiceConfigurationType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AuthorizationServiceConfigurationType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AuthorizationServiceConfigurationType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17852</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisInformation -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisInformation">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AxisInformation</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AxisInformation</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12079</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisScaleEnumeration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisScaleEnumeration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>AxisScaleEnumeration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>AxisScaleEnumeration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12077</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HighlyManagedAlarmConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MaintenanceConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProcessConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SafetyConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatisticalConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TestingConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrainingConditionClassType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BaseConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=11163</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Boolean"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ByteString"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataValue"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateTime"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticInfo"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Enumeration"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExpandedNodeId"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Guid"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeId"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Number"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#QualifiedName"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusCode"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#String"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Structure"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XmlElement"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that can have any valid DataType.</ua-core:description>
+        <ua-core:displayName>BaseDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=24</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmRateVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfoType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescriptionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDictionaryType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSetType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2Type"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsArrayType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SelectionListType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerVendorCapabilityType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsArrayType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsArrayType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsArrayType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionVariableType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseDataVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for variable that represents a process value.</ua-core:description>
+        <ua-core:displayName>BaseDataVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=63</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseModelChangeEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventQueueOverflowEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgressEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The base type for all events.</ua-core:description>
+        <ua-core:displayName>BaseEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2041</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseModelChangeEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseModelChangeEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneralModelChangeEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseModelChangeEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BaseModelChangeEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2132</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseObjectType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseObjectType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfigurationType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateFunctionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmMetricsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuthorizationServiceConfigurationType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseConditionClassType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeEncodingType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSystemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExtensionFieldsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FolderType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoricalDataConfigurationType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryServerCapabilitiesType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialConfigurationType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModellingRuleType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespaceMetadataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespacesType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubKeyServiceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleSetType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerCapabilitiesType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerConfigurationType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerRedundancyType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionsDiagnosticsSummaryType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateMachineType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TemporaryFileTransferType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VendorServerInfoType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseObjectType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The base type for all object nodes.</ua-core:description>
+        <ua-core:displayName>BaseObjectType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=58</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PropertyType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BaseVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The abstract base type for all variable nodes.</ua-core:description>
+        <ua-core:displayName>BaseVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=62</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BitFieldMaskDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BitFieldMaskDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BitFieldMaskDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A mask of 32 bits that can be updated individually by using the top 32 bits as a mask.</ua-core:description>
+        <ua-core:displayName>BitFieldMaskDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11737</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Boolean -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Boolean">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Boolean</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is either TRUE or FALSE.</ua-core:description>
+        <ua-core:displayName>Boolean</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=1</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerConnectionTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerConnectionTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15007</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerConnectionTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerConnectionTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15155</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerDataSetReaderTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerDataSetReaderTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15670</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerDataSetReaderTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerDataSetReaderTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21142</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerDataSetWriterTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerDataSetWriterTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15669</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerDataSetWriterTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerDataSetWriterTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21138</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerTransportQualityOfService -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerTransportQualityOfService">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerTransportQualityOfService</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerTransportQualityOfService</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15008</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerWriterGroupTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerWriterGroupTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15667</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BrokerWriterGroupTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BrokerWriterGroupTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21136</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfo -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfo">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BuildInfo</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BuildInfo</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=338</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfoType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfoType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfo"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>BuildInfoType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>BuildInfoType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=3051</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Byte -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Byte">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Byte</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between 0 and 255.</ua-core:description>
+        <ua-core:displayName>Byte</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=3</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ByteString -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ByteString">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationInstanceCertificate"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContinuationPoint"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Image"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ByteString</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a sequence of bytes.</ua-core:description>
+        <ua-core:displayName>ByteString</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateExpirationAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateExpirationAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>CertificateExpirationAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>CertificateExpirationAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=13225</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupFolderType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupFolderType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>CertificateGroupFolderType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>CertificateGroupFolderType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=13813</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>CertificateGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>CertificateGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12555</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationCertificateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HttpsCertificateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserCredentialCertificateType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>CertificateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>CertificateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=12556</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateUpdatedAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateUpdatedAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>CertificateUpdatedAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>CertificateUpdatedAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=12620</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ComplexNumberType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ComplexNumberType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ComplexNumberType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ComplexNumberType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12171</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AcknowledgeableConditionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DialogConditionType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ConditionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ConditionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2782</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ConditionVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ConditionVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9002</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConfigurationVersionDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConfigurationVersionDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ConfigurationVersionDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ConfigurationVersionDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14593</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ConnectionTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ConnectionTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15618</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ConnectionTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ConnectionTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17721</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilter -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilter">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ContentFilter</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ContentFilter</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=586</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilterElement -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilterElement">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ContentFilterElement</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ContentFilterElement</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=583</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContinuationPoint -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContinuationPoint">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ContinuationPoint</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An identifier for a suspended query or browse operation.</ua-core:description>
+        <ua-core:displayName>ContinuationPoint</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=521</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Counter -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Counter">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Counter</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A monotonically increasing value.</ua-core:description>
+        <ua-core:displayName>Counter</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=289</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CubeItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CubeItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:arrayDimensions>0,0,0</ua-core:arrayDimensions>
+        <ua-core:browseName>CubeItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>CubeItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12057</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">3</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnalogItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ArrayItemType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteItemType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A variable that contains live automation data.</ua-core:description>
+        <ua-core:displayName>DataItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2365</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldContentMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldContentMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetFieldContentMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetFieldContentMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15583</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldFlags -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldFlags">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetFieldFlags</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetFieldFlags</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15904</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFolderType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFolderType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetFolderType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetFolderType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14477</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetMetaDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetMetaDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetMetaDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetMetaDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14523</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetOrderingType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetOrderingType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetOrderingType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetOrderingType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=20408</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetReaderDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetReaderDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15623</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetReaderMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetReaderMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15629</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetReaderMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetReaderMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=21104</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetReaderTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetReaderTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15628</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetReaderTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetReaderTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15319</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetReaderType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetReaderType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15306</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetToWriter -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetToWriter">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetToWriter</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetToWriter</ua-core:displayName>
+        <ua-core:inverseName>WriterToDataSet</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14936</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#dataSetToWriter"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetWriterDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetWriterDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15597</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetWriterMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetWriterMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15605</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetWriterMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetWriterMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=21096</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetWriterTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetWriterTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15598</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetWriterTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetWriterTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15305</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataSetWriterType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataSetWriterType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15298</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDefinition -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDefinition">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDefinition"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDefinition"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeDefinition</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataTypeDefinition</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=97</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDescription"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleTypeDescription"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDescription"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataTypeDescription</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14525</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescriptionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescriptionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#String"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeDescriptionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for variable that represents the description of a data type encoding.</ua-core:description>
+        <ua-core:displayName>DataTypeDescriptionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=69</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDictionaryType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDictionaryType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ByteString"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeDictionaryType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for variable that represents the collection of data type decriptions.</ua-core:description>
+        <ua-core:displayName>DataTypeDictionaryType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=72</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeEncodingType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeEncodingType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeEncodingType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataTypeEncodingType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=76</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSchemaHeader -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSchemaHeader">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetMetaDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UABinaryFileDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeSchemaHeader</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataTypeSchemaHeader</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15534</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSystemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSystemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataTypeSystemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DataTypeSystemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=75</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataValue -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataValue">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DataValue</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a structure containing a value, a status code and timestamps.</ua-core:description>
+        <ua-core:displayName>DataValue</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=23</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DatagramConnectionTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DatagramConnectionTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17467</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DatagramConnectionTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DatagramConnectionTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15064</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DatagramWriterGroupTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DatagramWriterGroupTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15532</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DatagramWriterGroupTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DatagramWriterGroupTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21133</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Date -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Date">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Date</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A date value.</ua-core:description>
+        <ua-core:displayName>Date</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=293</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateString -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateString">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DateString</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A date formatted as defined in ISO 8601-2000.</ua-core:description>
+        <ua-core:displayName>DateString</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12881</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateTime -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateTime">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Date"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UtcTime"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DateTime</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a Gregorian calender date and time.</ua-core:description>
+        <ua-core:displayName>DateTime</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=13</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Decimal -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Decimal">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Decimal</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes an arbitrary precision decimal value.</ua-core:description>
+        <ua-core:displayName>Decimal</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=50</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DecimalString -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DecimalString">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DecimalString</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An arbitraty numeric value.</ua-core:description>
+        <ua-core:displayName>DecimalString</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12878</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteNodesItem -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteNodesItem">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DeleteNodesItem</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A request to delete a node to the server address space.</ua-core:description>
+        <ua-core:displayName>DeleteNodesItem</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=382</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteReferencesItem -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteReferencesItem">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DeleteReferencesItem</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A request to delete a node from the server address space.</ua-core:description>
+        <ua-core:displayName>DeleteReferencesItem</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=385</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeviceFailureEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeviceFailureEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DeviceFailureEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DeviceFailureEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2131</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticInfo -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticInfo">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DiagnosticInfo</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a structure containing diagnostics associated with a StatusCode.</ua-core:description>
+        <ua-core:displayName>DiagnosticInfo</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=25</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticsLevel -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticsLevel">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DiagnosticsLevel</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DiagnosticsLevel</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19723</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DialogConditionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DialogConditionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DialogConditionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DialogConditionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2830</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscoveryConfiguration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscoveryConfiguration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MdnsDiscoveryConfiguration"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DiscoveryConfiguration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for discovery configuration information.</ua-core:description>
+        <ua-core:displayName>DiscoveryConfiguration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12890</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscrepancyAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscrepancyAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DiscrepancyAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DiscrepancyAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17080</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OffNormalAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DiscreteAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DiscreteAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10523</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateDiscreteType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateValueDiscreteType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateDiscreteType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DiscreteItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DiscreteItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2372</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Double -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Double">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Duration"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Double</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an IEEE 754-1985 double precision floating point number.</ua-core:description>
+        <ua-core:displayName>Double</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DoubleComplexNumberType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DoubleComplexNumberType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DoubleComplexNumberType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>DoubleComplexNumberType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12172</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Duration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Duration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Duration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A period of time measured in milliseconds.</ua-core:description>
+        <ua-core:displayName>Duration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=290</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DurationString -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DurationString">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>DurationString</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A period of time formatted as defined in ISO 8601-2000.</ua-core:description>
+        <ua-core:displayName>DurationString</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12879</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EUInformation -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EUInformation">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EUInformation</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EUInformation</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=887</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ElementOperand -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ElementOperand">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ElementOperand</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ElementOperand</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=592</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointConfiguration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointConfiguration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EndpointConfiguration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EndpointConfiguration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=331</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EndpointDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The description of a endpoint that can be used to access a server.</ua-core:description>
+        <ua-core:displayName>EndpointDescription</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=312</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EndpointType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EndpointType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15528</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointUrlListDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointUrlListDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EndpointUrlListDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EndpointUrlListDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11943</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDefinition -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDefinition">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EnumDefinition</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EnumDefinition</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=100</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EnumDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EnumDescription</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15488</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumField -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumField">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EnumField</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EnumField</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=102</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumValueType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumValueType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumField"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EnumValueType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A mapping between a value of an enumerated type and a name and description.</ua-core:description>
+        <ua-core:displayName>EnumValueType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=7594</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Enumeration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Enumeration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisScaleEnumeration"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerTransportQualityOfService"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetOrderingType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticsLevel"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExceptionDeviationFormat"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperator"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryUpdateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityCriteriaType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MessageSecurityMode"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamingRuleType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeAttributesMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeClass"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OpenFileMode"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OverrideValueHandling"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PerformUpdateType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterClassification"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubState"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundancySupport"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityTokenRequestType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerState"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListMasks"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Enumeration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an enumerated DataType.</ua-core:description>
+        <ua-core:displayName>Enumeration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=29</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventFilter -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventFilter">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EventFilter</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EventFilter</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=725</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventNotifierType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventNotifierType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EventNotifierType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EventNotifierType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15033</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventQueueOverflowEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventQueueOverflowEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>EventQueueOverflowEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>EventQueueOverflowEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=3035</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExceptionDeviationFormat -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExceptionDeviationFormat">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExceptionDeviationFormat</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExceptionDeviationFormat</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=890</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveDeviationAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveDeviationAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExclusiveDeviationAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExclusiveDeviationAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9764</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLevelAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLevelAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExclusiveLevelAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExclusiveLevelAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9482</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveDeviationAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLevelAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveRateOfChangeAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExclusiveLimitAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExclusiveLimitAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9341</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitStateMachineType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitStateMachineType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExclusiveLimitStateMachineType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExclusiveLimitStateMachineType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9318</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveRateOfChangeAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveRateOfChangeAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExclusiveRateOfChangeAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExclusiveRateOfChangeAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9623</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExpandedNodeId -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExpandedNodeId">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExpandedNodeId</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an absolute identifier for a node.</ua-core:description>
+        <ua-core:displayName>ExpandedNodeId</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=18</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExtensionFieldsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExtensionFieldsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ExtensionFieldsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ExtensionFieldsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15489</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldMetaData -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldMetaData">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FieldMetaData</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FieldMetaData</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14524</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldTargetDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldTargetDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FieldTargetDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FieldTargetDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14744</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileDirectoryType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileDirectoryType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FileDirectoryType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FileDirectoryType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=13353</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileTransferStateMachineType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileTransferStateMachineType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FileTransferStateMachineType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FileTransferStateMachineType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15803</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddressSpaceFileType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FileType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An object that represents a file that can be accessed via the server.</ua-core:description>
+        <ua-core:displayName>FileType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11575</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperand -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperand">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeOperand"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ElementOperand"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LiteralOperand"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleAttributeOperand"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FilterOperand</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FilterOperand</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=589</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperator -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperator">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FilterOperator</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FilterOperator</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=576</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateMachineType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateMachineType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitStateMachineType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileTransferStateMachineType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramStateMachineType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ShelvedStateMachineType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FiniteStateMachineType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FiniteStateMachineType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2771</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FiniteStateVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FiniteStateVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2760</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteTransitionVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteTransitionVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FiniteTransitionVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>FiniteTransitionVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2767</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Float -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Float">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Float</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an IEEE 754-1985 single precision floating point number.</ua-core:description>
+        <ua-core:displayName>Float</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FolderType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FolderType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupFolderType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFolderType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileDirectoryType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OperationLimitsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupFolderType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FolderType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for objects that organize other nodes.</ua-core:description>
+        <ua-core:displayName>FolderType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=61</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FromState -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FromState">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>FromState</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for a reference to the state before a transition.</ua-core:description>
+        <ua-core:displayName>FromState</ua-core:displayName>
+        <ua-core:inverseName>ToTransition</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=51</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#fromState"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneralModelChangeEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneralModelChangeEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>GeneralModelChangeEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>GeneralModelChangeEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2133</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneratesEvent -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneratesEvent">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlwaysGeneratesEvent"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>GeneratesEvent</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for references from a node to an event type that is raised by node.</ua-core:description>
+        <ua-core:displayName>GeneratesEvent</ua-core:displayName>
+        <ua-core:inverseName>GeneratedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=41</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#generatesEvent"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Guid -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Guid">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Guid</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a 128-bit globally unique identifier.</ua-core:description>
+        <ua-core:displayName>Guid</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasAlarmSuppressionGroup -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasAlarmSuppressionGroup">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasAlarmSuppressionGroup</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasAlarmSuppressionGroup</ua-core:displayName>
+        <ua-core:inverseName>IsAlarmSuppressionGroupOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=16361</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasAlarmSuppressionGroup"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCause -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCause">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasCause</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for a reference to a method that can cause a transition to occur.</ua-core:description>
+        <ua-core:displayName>HasCause</ua-core:displayName>
+        <ua-core:inverseName>MayBeCausedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=53</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasCause"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasChild -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasChild">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Aggregates"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubtype"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasChild</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The abstract base type for all non-looping hierarchical references.</ua-core:description>
+        <ua-core:displayName>HasChild</ua-core:displayName>
+        <ua-core:inverseName>ChildOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=34</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasChild"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasComponent -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasComponent">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasAlarmSuppressionGroup"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetReader"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetWriter"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasOrderedComponent"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasPubSubConnection"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasComponent</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical reference from a node to its component.</ua-core:description>
+        <ua-core:displayName>HasComponent</ua-core:displayName>
+        <ua-core:inverseName>ComponentOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=47</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasComponent"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCondition -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCondition">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasCondition</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasCondition</ua-core:displayName>
+        <ua-core:inverseName>IsConditionOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9006</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasCondition"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetReader -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetReader">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasDataSetReader</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasDataSetReader</ua-core:displayName>
+        <ua-core:inverseName>IsReaderInGroup</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15297</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDataSetReader"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetWriter -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetWriter">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasDataSetWriter</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasDataSetWriter</ua-core:displayName>
+        <ua-core:inverseName>IsWriterInGroup</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15296</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDataSetWriter"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for references from data type encoding nodes to data type description nodes.</ua-core:description>
+        <ua-core:displayName>HasDescription</ua-core:displayName>
+        <ua-core:inverseName>DescriptionOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=39</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasDescription"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffect -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffect">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectDisable"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectEnable"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectSuppressed"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectUnsuppressed"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEffect</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for a reference to an event that may be raised when a transition occurs.</ua-core:description>
+        <ua-core:displayName>HasEffect</ua-core:displayName>
+        <ua-core:inverseName>MayBeEffectedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=54</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffect"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectDisable -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectDisable">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEffectDisable</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasEffectDisable</ua-core:displayName>
+        <ua-core:inverseName>MayBeDisabledBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17276</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectDisable"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectEnable -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectEnable">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEffectEnable</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasEffectEnable</ua-core:displayName>
+        <ua-core:inverseName>MayBeEnabledBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17983</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectEnable"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectSuppressed -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectSuppressed">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEffectSuppressed</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasEffectSuppressed</ua-core:displayName>
+        <ua-core:inverseName>MayBeSuppressedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17984</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectSuppressed"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectUnsuppressed -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectUnsuppressed">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEffectUnsuppressed</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasEffectUnsuppressed</ua-core:displayName>
+        <ua-core:inverseName>MayBeUnsuppressedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17985</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEffectUnsuppressed"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEncoding -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEncoding">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEncoding</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for references from data type nodes to to data type encoding nodes.</ua-core:description>
+        <ua-core:displayName>HasEncoding</ua-core:displayName>
+        <ua-core:inverseName>EncodingOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=38</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEncoding"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEventSource -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEventSource">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasNotifier"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasEventSource</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical references that are used to organize event sources.</ua-core:description>
+        <ua-core:displayName>HasEventSource</ua-core:displayName>
+        <ua-core:inverseName>EventSourceOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=36</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasEventSource"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasFalseSubState -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasFalseSubState">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasFalseSubState</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasFalseSubState</ua-core:displayName>
+        <ua-core:inverseName>IsFalseSubStateOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9005</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasFalseSubState"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasHistoricalConfiguration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasHistoricalConfiguration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasHistoricalConfiguration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for a reference to the historical configuration for a data variable.</ua-core:description>
+        <ua-core:displayName>HasHistoricalConfiguration</ua-core:displayName>
+        <ua-core:inverseName>HistoricalConfigurationOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=56</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasHistoricalConfiguration"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasModellingRule -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasModellingRule">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasModellingRule</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for references from instance declarations to modelling rule nodes.</ua-core:description>
+        <ua-core:displayName>HasModellingRule</ua-core:displayName>
+        <ua-core:inverseName>ModellingRuleOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=37</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasModellingRule"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasNotifier -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasNotifier">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasNotifier</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical references that are used to indicate how events propagate from node to node.</ua-core:description>
+        <ua-core:displayName>HasNotifier</ua-core:displayName>
+        <ua-core:inverseName>NotifierOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=48</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasNotifier"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasOrderedComponent -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasOrderedComponent">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasOrderedComponent</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical reference from a node to its component when the order of references matters.</ua-core:description>
+        <ua-core:displayName>HasOrderedComponent</ua-core:displayName>
+        <ua-core:inverseName>OrderedComponentOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=49</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasOrderedComponent"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasProperty -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasProperty">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasProperty</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical reference from a node to its property.</ua-core:description>
+        <ua-core:displayName>HasProperty</ua-core:displayName>
+        <ua-core:inverseName>PropertyOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=46</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasProperty"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasPubSubConnection -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasPubSubConnection">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasPubSubConnection</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasPubSubConnection</ua-core:displayName>
+        <ua-core:inverseName>PubSubConnectionOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14476</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasPubSubConnection"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubStateMachine -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubStateMachine">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasSubStateMachine</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for a reference to a substate for a state.</ua-core:description>
+        <ua-core:displayName>HasSubStateMachine</ua-core:displayName>
+        <ua-core:inverseName>SubStateMachineOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=117</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasSubStateMachine"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubtype -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubtype">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasSubtype</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for non-looping hierarchical references that are used to define sub types.</ua-core:description>
+        <ua-core:displayName>HasSubtype</ua-core:displayName>
+        <ua-core:inverseName>SubtypeOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=45</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasSubtype"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTrueSubState -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTrueSubState">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasTrueSubState</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HasTrueSubState</ua-core:displayName>
+        <ua-core:inverseName>IsTrueSubStateOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9004</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasTrueSubState"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTypeDefinition -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTypeDefinition">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HasTypeDefinition</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for references from a instance node its type defintion node.</ua-core:description>
+        <ua-core:displayName>HasTypeDefinition</ua-core:displayName>
+        <ua-core:inverseName>TypeDefinitionOf</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=40</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hasTypeDefinition"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HierarchicalReferences -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HierarchicalReferences">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetToWriter"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasChild"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEventSource"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Organizes"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HierarchicalReferences</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The abstract base type for all hierarchical references.</ua-core:description>
+        <ua-core:displayName>HierarchicalReferences</ua-core:displayName>
+        <ua-core:inverseName>HierarchicalReferences</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=33</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#hierarchicalReferences"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HighlyManagedAlarmConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HighlyManagedAlarmConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HighlyManagedAlarmConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HighlyManagedAlarmConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17219</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoricalDataConfigurationType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoricalDataConfigurationType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HistoricalDataConfigurationType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HistoricalDataConfigurationType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2318</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEvent -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEvent">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HistoryEvent</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HistoryEvent</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=659</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEventFieldList -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEventFieldList">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HistoryEventFieldList</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HistoryEventFieldList</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=920</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryServerCapabilitiesType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryServerCapabilitiesType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HistoryServerCapabilitiesType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HistoryServerCapabilitiesType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2330</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryUpdateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryUpdateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HistoryUpdateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HistoryUpdateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11234</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HttpsCertificateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HttpsCertificateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>HttpsCertificateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>HttpsCertificateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12558</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>IdType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type of identifier used in a node id.</ua-core:description>
+        <ua-core:displayName>IdType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=256</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityCriteriaType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityCriteriaType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>IdentityCriteriaType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>IdentityCriteriaType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15632</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityMappingRuleType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityMappingRuleType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>IdentityMappingRuleType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>IdentityMappingRuleType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15634</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Image -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Image">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageBMP"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageGIF"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageJPG"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImagePNG"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Image</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an image encoded as a string of bytes.</ua-core:description>
+        <ua-core:displayName>Image</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=30</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageBMP -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageBMP">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ImageBMP</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An image encoded in BMP format.</ua-core:description>
+        <ua-core:displayName>ImageBMP</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2000</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageGIF -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageGIF">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ImageGIF</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An image encoded in GIF format.</ua-core:description>
+        <ua-core:displayName>ImageGIF</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2001</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:arrayDimensions>0,0</ua-core:arrayDimensions>
+        <ua-core:browseName>ImageItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ImageItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12047</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageJPG -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageJPG">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ImageJPG</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An image encoded in JPEG format.</ua-core:description>
+        <ua-core:displayName>ImageJPG</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2002</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImagePNG -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImagePNG">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ImagePNG</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An image encoded in PNG format.</ua-core:description>
+        <ua-core:displayName>ImagePNG</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2003</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InitialStateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InitialStateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>InitialStateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>InitialStateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2309</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InstrumentDiagnosticAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InstrumentDiagnosticAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>InstrumentDiagnosticAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>InstrumentDiagnosticAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=18347</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int16 -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int16">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Int16</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between −32,768 and 32,767.</ua-core:description>
+        <ua-core:displayName>Int16</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=4</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int32 -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int32">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Int32</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between −2,147,483,648  and 2,147,483,647.</ua-core:description>
+        <ua-core:displayName>Int32</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=6</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int64 -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int64">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Int64</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between −9,223,372,036,854,775,808 and 9,223,372,036,854,775,807.</ua-core:description>
+        <ua-core:displayName>Int64</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=8</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Integer -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Integer">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int16"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int32"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int64"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SByte"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Integer</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that can have any integer DataType.</ua-core:description>
+        <ua-core:displayName>Integer</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=27</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IntegerId -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IntegerId">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>IntegerId</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A numeric identifier for an object.</ua-core:description>
+        <ua-core:displayName>IntegerId</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=288</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IssuedIdentityToken -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IssuedIdentityToken">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>IssuedIdentityToken</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A token representing a user identified by a WS-Security XML token.</ua-core:description>
+        <ua-core:displayName>IssuedIdentityToken</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=938</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetMessageContentMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetMessageContentMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonDataSetMessageContentMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonDataSetMessageContentMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15658</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonDataSetReaderMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonDataSetReaderMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15665</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonDataSetReaderMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonDataSetReaderMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21130</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonDataSetWriterMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonDataSetWriterMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15664</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonDataSetWriterMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonDataSetWriterMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21128</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonNetworkMessageContentMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonNetworkMessageContentMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonNetworkMessageContentMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonNetworkMessageContentMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15654</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonWriterGroupMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonWriterGroupMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15657</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>JsonWriterGroupMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>JsonWriterGroupMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21126</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialDeletedAuditEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialUpdatedAuditEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>KeyCredentialAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>KeyCredentialAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=18011</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialConfigurationType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialConfigurationType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>KeyCredentialConfigurationType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>KeyCredentialConfigurationType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=18001</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialDeletedAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialDeletedAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>KeyCredentialDeletedAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>KeyCredentialDeletedAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=18047</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialUpdatedAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialUpdatedAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>KeyCredentialUpdatedAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>KeyCredentialUpdatedAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=18029</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyValuePair -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyValuePair">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>KeyValuePair</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>KeyValuePair</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14533</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LimitAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LimitAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLimitAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>LimitAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>LimitAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2955</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LiteralOperand -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LiteralOperand">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>LiteralOperand</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>LiteralOperand</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=595</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocaleId -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocaleId">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>LocaleId</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An identifier for a user locale.</ua-core:description>
+        <ua-core:displayName>LocaleId</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=295</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>LocalizedText</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is human readable Unicode text with a locale identifier.</ua-core:description>
+        <ua-core:displayName>LocalizedText</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MaintenanceConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MaintenanceConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>MaintenanceConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>MaintenanceConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=11165</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MdnsDiscoveryConfiguration -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MdnsDiscoveryConfiguration">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>MdnsDiscoveryConfiguration</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The discovery information needed for mDNS registration.</ua-core:description>
+        <ua-core:displayName>MdnsDiscoveryConfiguration</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12891</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MessageSecurityMode -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MessageSecurityMode">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>MessageSecurityMode</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type of security to use on a message.</ua-core:description>
+        <ua-core:displayName>MessageSecurityMode</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=302</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModelChangeStructureDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModelChangeStructureDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ModelChangeStructureDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ModelChangeStructureDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=877</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModellingRuleType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModellingRuleType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ModellingRuleType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for an object that describes how an instance declaration is used when a type is instantiated.</ua-core:description>
+        <ua-core:displayName>ModellingRuleType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=77</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MonitoringFilter -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MonitoringFilter">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventFilter"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>MonitoringFilter</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>MonitoringFilter</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=719</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateDiscreteType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateDiscreteType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInteger"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>MultiStateDiscreteType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>MultiStateDiscreteType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2376</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateValueDiscreteType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateValueDiscreteType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Number"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>MultiStateValueDiscreteType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>MultiStateValueDiscreteType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11238</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NDimensionArrayItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NDimensionArrayItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NDimensionArrayItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NDimensionArrayItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12068</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespaceMetadataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespaceMetadataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NamespaceMetadataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Provides the metadata for a namespace used by the server.</ua-core:description>
+        <ua-core:displayName>NamespaceMetadataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11616</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespacesType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespacesType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NamespacesType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A container for the namespace metadata provided by the server.</ua-core:description>
+        <ua-core:displayName>NamespacesType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11645</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamingRuleType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamingRuleType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NamingRuleType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that specifies the significance of the BrowseName for an instance declaration.</ua-core:description>
+        <ua-core:displayName>NamingRuleType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=120</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NetworkAddressDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NetworkAddressDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15502</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NetworkAddressType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NetworkAddressType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=21145</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NetworkAddressUrlDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NetworkAddressUrlDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15510</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NetworkAddressUrlType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NetworkAddressUrlType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21147</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkGroupDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkGroupDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NetworkGroupDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NetworkGroupDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11944</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeAttributesMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeAttributesMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NodeAttributesMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The bits used to specify default attributes for a new node.</ua-core:description>
+        <ua-core:displayName>NodeAttributesMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=348</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeClass -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeClass">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NodeClass</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A mask specifying the class of the node.</ua-core:description>
+        <ua-core:displayName>NodeClass</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=257</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeId -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeId">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionAuthenticationToken"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NodeId</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an identifier for a node within a Server address space.</ua-core:description>
+        <ua-core:displayName>NodeId</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveDeviationAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveDeviationAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonExclusiveDeviationAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NonExclusiveDeviationAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10368</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLevelAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLevelAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonExclusiveLevelAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NonExclusiveLevelAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10060</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLimitAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLimitAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveDeviationAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLevelAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveRateOfChangeAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonExclusiveLimitAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NonExclusiveLimitAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9906</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveRateOfChangeAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveRateOfChangeAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonExclusiveRateOfChangeAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NonExclusiveRateOfChangeAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10214</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonHierarchicalReferences -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonHierarchicalReferences">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FromState"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneratesEvent"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCause"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCondition"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDescription"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffect"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEncoding"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasFalseSubState"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasModellingRule"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubStateMachine"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTrueSubState"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTypeDefinition"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ToState"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonHierarchicalReferences</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The abstract base type for all non-hierarchical references.</ua-core:description>
+        <ua-core:displayName>NonHierarchicalReferences</ua-core:displayName>
+        <ua-core:inverseName>NonHierarchicalReferences</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=32</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#nonHierarchicalReferences"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentNetworkRedundancyType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentNetworkRedundancyType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonTransparentNetworkRedundancyType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>NonTransparentNetworkRedundancyType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11945</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentRedundancyType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentRedundancyType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentNetworkRedundancyType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NonTransparentRedundancyType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Identifies the capabilties of server that supports non-transparent redundancy.</ua-core:description>
+        <ua-core:displayName>NonTransparentRedundancyType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2039</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NormalizedString -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NormalizedString">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NormalizedString</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A string normalized based on the rules in the unicode specification.</ua-core:description>
+        <ua-core:displayName>NormalizedString</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12877</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Number -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Number">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Decimal"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Double"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Float"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Integer"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInteger"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Number</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that can have any numeric DataType.</ua-core:description>
+        <ua-core:displayName>Number</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=26</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NumericRange -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NumericRange">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>NumericRange</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Specifies a range of array indexes.</ua-core:description>
+        <ua-core:displayName>NumericRange</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=291</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OffNormalAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OffNormalAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InstrumentDiagnosticAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemDiagnosticAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemOffNormalAlarmType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TripAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>OffNormalAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>OffNormalAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10637</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OpenFileMode -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OpenFileMode">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>OpenFileMode</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>OpenFileMode</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11939</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OperationLimitsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OperationLimitsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>OperationLimitsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Identifies the operation limits imposed by the server.</ua-core:description>
+        <ua-core:displayName>OperationLimitsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11564</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSet -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSet">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>OptionSet</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>This abstract Structured DataType is the base DataType for all DataTypes representing a bit mask.</ua-core:description>
+        <ua-core:displayName>OptionSet</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12755</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSetType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSetType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>OptionSetType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>OptionSetType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11487</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Organizes -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Organizes">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupMember"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Organizes</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for hierarchical references that are used to organize nodes.</ua-core:description>
+        <ua-core:displayName>Organizes</ua-core:displayName>
+        <ua-core:inverseName>OrganizedBy</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=35</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#organizes"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OverrideValueHandling -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OverrideValueHandling">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>OverrideValueHandling</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>OverrideValueHandling</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15874</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PerformUpdateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PerformUpdateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PerformUpdateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PerformUpdateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11293</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PermissionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PermissionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PermissionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PermissionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=94</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProcessConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProcessConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProcessConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProcessConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=11164</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2DataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2DataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramDiagnostic2DataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgramDiagnostic2DataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15396</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2Type -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2Type">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2DataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramDiagnostic2Type</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgramDiagnostic2Type</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15383</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramDiagnosticDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgramDiagnosticDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=894</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramDiagnosticType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgramDiagnosticType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2380</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramStateMachineType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramStateMachineType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramStateMachineType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A state machine for a program.</ua-core:description>
+        <ua-core:displayName>ProgramStateMachineType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2391</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramTransitionAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgramTransitionAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=3806</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgramTransitionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgramTransitionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2378</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgressEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgressEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ProgressEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ProgressEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=11436</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PropertyType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PropertyType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PropertyType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for variable that represents a property of another node.</ua-core:description>
+        <ua-core:displayName>PropertyType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=68</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubCommunicationFailureEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubCommunicationFailureEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubCommunicationFailureEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubCommunicationFailureEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15563</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConfigurationDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConfigurationDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubConfigurationDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubConfigurationDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15530</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubConnectionDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubConnectionDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15617</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubConnectionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubConnectionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14209</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsConnectionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsConnectionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsConnectionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsConnectionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19786</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterClassification -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterClassification">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsCounterClassification</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsCounterClassification</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19730</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt32"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsCounterType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsCounterType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19725</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetReaderType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetReaderType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsDataSetReaderType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsDataSetReaderType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=20027</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetWriterType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetWriterType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsDataSetWriterType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsDataSetWriterType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19968</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsReaderGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsReaderGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsReaderGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsReaderGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19903</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsRootType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsRootType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsRootType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsRootType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19732</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsConnectionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetReaderType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetWriterType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsReaderGroupType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsRootType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsWriterGroupType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19677</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsWriterGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsWriterGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubDiagnosticsWriterGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubDiagnosticsWriterGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19834</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubGroupDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubGroupDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15609</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14232</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubKeyServiceType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubKeyServiceType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishSubscribeType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubKeyServiceType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubKeyServiceType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15906</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubState -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubState">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubState</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubState</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14647</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubCommunicationFailureEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubTransportLimitsExceedEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubStatusEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubStatusEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15535</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubStatusType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubStatusType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14643</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubTransportLimitsExceedEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubTransportLimitsExceedEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PubSubTransportLimitsExceedEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PubSubTransportLimitsExceedEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15548</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishSubscribeType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishSubscribeType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishSubscribeType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishSubscribeType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14416</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedDataItemsDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedDataItemsDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15581</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedDataItemsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedDataItemsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14534</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedDataSetDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedDataSetDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15578</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetSourceDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetSourceDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedDataSetSourceDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedDataSetSourceDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15580</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedDataSetType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedDataSetType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14509</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedEventsDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedEventsDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15582</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedEventsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedEventsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14572</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedVariableDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedVariableDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>PublishedVariableDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>PublishedVariableDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=14273</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#QualifiedName -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#QualifiedName">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>QualifiedName</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a name qualified by a namespace.</ua-core:description>
+        <ua-core:displayName>QualifiedName</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=20</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Range -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Range">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Range</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>Range</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=884</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ReaderGroupDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ReaderGroupDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15520</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ReaderGroupMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ReaderGroupMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15622</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ReaderGroupMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ReaderGroupMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=21091</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ReaderGroupTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ReaderGroupTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15621</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ReaderGroupTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ReaderGroupTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=21090</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ReaderGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ReaderGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17999</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundancySupport -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundancySupport">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RedundancySupport</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RedundancySupport</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=851</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundantServerDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundantServerDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RedundantServerDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RedundantServerDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=853</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#References -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#References">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HierarchicalReferences"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonHierarchicalReferences"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>References</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The abstract base type for all references.</ua-core:description>
+        <ua-core:displayName>References</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=31</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#references"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshEndEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshEndEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RefreshEndEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RefreshEndEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2788</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshRequiredEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshRequiredEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RefreshRequiredEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RefreshRequiredEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2789</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshStartEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshStartEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RefreshStartEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RefreshStartEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2787</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RegisteredServer -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RegisteredServer">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RegisteredServer</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The information required to register a server with a discovery server.</ua-core:description>
+        <ua-core:displayName>RegisteredServer</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=432</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePath -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePath">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RelativePath</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A relative path constructed from reference types and browse names.</ua-core:description>
+        <ua-core:displayName>RelativePath</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=540</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePathElement -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePathElement">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RelativePathElement</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>An element in a relative path.</ua-core:description>
+        <ua-core:displayName>RelativePathElement</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=537</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleMappingRuleChangedAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleMappingRuleChangedAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RoleMappingRuleChangedAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RoleMappingRuleChangedAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17641</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RolePermissionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RolePermissionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RolePermissionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RolePermissionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=96</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleSetType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleSetType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RoleSetType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A container for the roles supported by the server.</ua-core:description>
+        <ua-core:displayName>RoleSetType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15607</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RoleType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RoleType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15620</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaMinApplicationCertificateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaMinApplicationCertificateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RsaMinApplicationCertificateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RsaMinApplicationCertificateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12559</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaSha256ApplicationCertificateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaSha256ApplicationCertificateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>RsaSha256ApplicationCertificateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>RsaSha256ApplicationCertificateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12560</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SByte -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SByte">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SByte</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between -128 and 127.</ua-core:description>
+        <ua-core:displayName>SByte</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SafetyConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SafetyConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SafetyConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SafetyConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17218</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsArrayType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsArrayType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SamplingIntervalDiagnosticsArrayType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SamplingIntervalDiagnosticsArrayType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2164</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SamplingIntervalDiagnosticsDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SamplingIntervalDiagnosticsDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=856</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SamplingIntervalDiagnosticsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SamplingIntervalDiagnosticsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2165</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupFolderType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupFolderType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SecurityGroupFolderType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SecurityGroupFolderType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15452</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SecurityGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SecurityGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15471</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityTokenRequestType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityTokenRequestType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SecurityTokenRequestType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Indicates whether a token if being created or renewed.</ua-core:description>
+        <ua-core:displayName>SecurityTokenRequestType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=315</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SelectionListType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SelectionListType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SelectionListType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SelectionListType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=16309</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SemanticChangeEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SemanticChangeEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2738</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeStructureDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeStructureDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SemanticChangeStructureDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SemanticChangeStructureDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=897</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerCapabilitiesType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerCapabilitiesType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerCapabilitiesType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes the capabilities supported by the server.</ua-core:description>
+        <ua-core:displayName>ServerCapabilitiesType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2013</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerConfigurationType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerConfigurationType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerConfigurationType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerConfigurationType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12581</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerDiagnosticsSummaryDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerDiagnosticsSummaryDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=859</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerDiagnosticsSummaryType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerDiagnosticsSummaryType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2150</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerDiagnosticsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The diagnostics information for a server.</ua-core:description>
+        <ua-core:displayName>ServerDiagnosticsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2020</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerOnNetwork -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerOnNetwork">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerOnNetwork</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerOnNetwork</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12189</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerRedundancyType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerRedundancyType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentRedundancyType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransparentRedundancyType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerRedundancyType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for an object that describe how a server supports redundancy.</ua-core:description>
+        <ua-core:displayName>ServerRedundancyType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2034</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerState -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerState">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerState</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerState</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=852</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerStatusDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerStatusDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=862</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerStatusType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerStatusType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2138</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Specifies the current status and capabilities of the server.</ua-core:description>
+        <ua-core:displayName>ServerType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2004</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerVendorCapabilityType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerVendorCapabilityType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServerVendorCapabilityType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServerVendorCapabilityType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2137</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServiceCounterDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServiceCounterDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ServiceCounterDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ServiceCounterDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=871</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionAuthenticationToken -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionAuthenticationToken">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionAuthenticationToken</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A unique identifier for a session used to authenticate requests.</ua-core:description>
+        <ua-core:displayName>SessionAuthenticationToken</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=388</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsArrayType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsArrayType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionDiagnosticsArrayType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SessionDiagnosticsArrayType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2196</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionDiagnosticsDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SessionDiagnosticsDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=865</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsObjectType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsObjectType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionDiagnosticsObjectType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A container for session level diagnostics information.</ua-core:description>
+        <ua-core:displayName>SessionDiagnosticsObjectType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2029</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionDiagnosticsVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SessionDiagnosticsVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2197</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsArrayType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsArrayType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionSecurityDiagnosticsArrayType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SessionSecurityDiagnosticsArrayType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2243</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionSecurityDiagnosticsDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SessionSecurityDiagnosticsDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=868</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionSecurityDiagnosticsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SessionSecurityDiagnosticsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2244</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionsDiagnosticsSummaryType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionsDiagnosticsSummaryType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SessionsDiagnosticsSummaryType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Provides a summary of session level diagnostics.</ua-core:description>
+        <ua-core:displayName>SessionsDiagnosticsSummaryType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2026</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ShelvedStateMachineType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ShelvedStateMachineType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ShelvedStateMachineType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>ShelvedStateMachineType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2929</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SignedSoftwareCertificate -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SignedSoftwareCertificate">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SignedSoftwareCertificate</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A software certificate with a digital signature.</ua-core:description>
+        <ua-core:displayName>SignedSoftwareCertificate</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=344</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleAttributeOperand -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleAttributeOperand">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SimpleAttributeOperand</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SimpleAttributeOperand</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=601</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleTypeDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleTypeDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SimpleTypeDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SimpleTypeDescription</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15005</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateMachineType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateMachineType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateMachineType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StateMachineType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StateMachineType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2299</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InitialStateType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2307</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateVariableType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateVariableType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StateVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StateVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2755</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatisticalConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatisticalConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StatisticalConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StatisticalConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=18665</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusCode -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusCode">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StatusCode</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a code representing the outcome of an operation by a Server.</ua-core:description>
+        <ua-core:displayName>StatusCode</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=19</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusResult -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusResult">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StatusResult</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StatusResult</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=299</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#String -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#String">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateString"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DecimalString"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DurationString"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocaleId"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NormalizedString"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NumericRange"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Time"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeString"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>String</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is a sequence of printable Unicode characters.</ua-core:description>
+        <ua-core:displayName>String</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Structure -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Structure">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddNodesItem"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddReferencesItem"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfiguration"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Annotation"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationDescription"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Argument"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisInformation"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfo"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ComplexNumberType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConfigurationVersionDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilter"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilterElement"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDefinition"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescription"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSchemaHeader"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteNodesItem"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteReferencesItem"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscoveryConfiguration"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DoubleComplexNumberType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EUInformation"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointConfiguration"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointDescription"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointUrlListDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumValueType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldMetaData"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldTargetDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperand"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEvent"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEventFieldList"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityMappingRuleType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyValuePair"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModelChangeStructureDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MonitoringFilter"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkGroupDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSet"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2DataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConfigurationDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetSourceDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedVariableDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Range"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundantServerDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RegisteredServer"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePath"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePathElement"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RolePermissionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeStructureDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerOnNetwork"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServiceCounterDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SignedSoftwareCertificate"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusResult"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureField"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeZoneDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Union"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserIdentityToken"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenPolicy"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XVType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Structure</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is any type of structure that can be described with a data encoding.</ua-core:description>
+        <ua-core:displayName>Structure</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=22</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDefinition -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDefinition">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StructureDefinition</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StructureDefinition</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=99</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDescription -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDescription">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StructureDescription</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StructureDescription</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15487</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureField -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureField">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StructureField</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StructureField</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=101</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>StructureType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>StructureType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=98</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscribedDataSetDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscribedDataSetDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15630</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscribedDataSetMirrorDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscribedDataSetMirrorDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15635</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscribedDataSetMirrorType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscribedDataSetMirrorType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15127</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscribedDataSetType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscribedDataSetType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15108</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsArrayType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsArrayType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscriptionDiagnosticsArrayType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscriptionDiagnosticsArrayType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2171</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscriptionDiagnosticsDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscriptionDiagnosticsDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=874</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SubscriptionDiagnosticsType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SubscriptionDiagnosticsType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2172</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SystemConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SystemConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=11166</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemDiagnosticAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemDiagnosticAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SystemDiagnosticAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SystemDiagnosticAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=18496</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeviceFailureEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshEndEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshRequiredEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshStartEventType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemStatusChangeEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SystemEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SystemEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=2130</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemOffNormalAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemOffNormalAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateExpirationAlarmType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SystemOffNormalAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SystemOffNormalAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=11753</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemStatusChangeEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemStatusChangeEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>SystemStatusChangeEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>SystemStatusChangeEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=11446</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TargetVariablesDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TargetVariablesDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15631</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TargetVariablesType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TargetVariablesType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15111</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TemporaryFileTransferType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TemporaryFileTransferType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TemporaryFileTransferType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TemporaryFileTransferType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15744</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TestingConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TestingConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TestingConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TestingConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17221</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Time -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Time">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Time</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A time value specified as HH:MM:SS.SSS.</ua-core:description>
+        <ua-core:displayName>Time</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=292</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeString -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeString">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TimeString</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A time formatted as defined in ISO 8601-2000.</ua-core:description>
+        <ua-core:displayName>TimeString</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12880</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeZoneDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeZoneDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TimeZoneDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TimeZoneDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=8912</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ToState -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ToState">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAReferenceType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>ToState</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The type for a reference to the state after a transition.</ua-core:description>
+        <ua-core:displayName>ToState</ua-core:displayName>
+        <ua-core:inverseName>FromTransition</ua-core:inverseName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=52</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:symmetric rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:symmetric>
+        <ua-core:objectProperty rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#toState"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrainingConditionClassType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrainingConditionClassType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TrainingConditionClassType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TrainingConditionClassType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17220</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionEventType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TransitionEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TransitionEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2311</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TransitionType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TransitionType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2310</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteTransitionVariableType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TransitionVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TransitionVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2762</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransparentRedundancyType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransparentRedundancyType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TransparentRedundancyType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Identifies the capabilties of server that supports transparent redundancy.</ua-core:description>
+        <ua-core:displayName>TransparentRedundancyType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2036</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TripAlarmType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TripAlarmType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TripAlarmType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TripAlarmType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=10751</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TrustListDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TrustListDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12554</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListMasks -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListMasks">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TrustListMasks</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TrustListMasks</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12552</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TrustListType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TrustListType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12522</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListUpdatedAuditEventType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListUpdatedAuditEventType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TrustListUpdatedAuditEventType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TrustListUpdatedAuditEventType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=12561</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateDiscreteType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateDiscreteType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Boolean"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TwoStateDiscreteType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TwoStateDiscreteType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2373</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-2</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateVariableType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateVariableType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>TwoStateVariableType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>TwoStateVariableType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=8995</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">-1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UABinaryFileDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UABinaryFileDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UABinaryFileDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UABinaryFileDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15006</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UANodeSet_ua -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UANodeSet_ua">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UANodeSet"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelExType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessRestrictionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AcknowledgeableConditionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddNodesItem"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddReferencesItem"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AddressSpaceFileType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfiguration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateConfigurationType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AggregateFunctionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Aggregates"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmConditionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupMember"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmMetricsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlarmRateVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AlwaysGeneratesEvent"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnalogItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Annotation"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnonymousIdentityToken"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationCertificateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationInstanceCertificate"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ApplicationType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Argument"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ArrayItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeOperand"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeWriteMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AudioVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditActivateSessionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddNodesEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditAddReferencesEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCancelEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateDataMismatchEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateExpiredEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateInvalidEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateMismatchEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateRevokedEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCertificateUntrustedEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditChannelEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionAcknowledgeEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionCommentEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionConfirmEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEnableEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionOutOfServiceEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionResetEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionRespondEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionShelvingEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSilenceEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditConditionSuppressEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditCreateSessionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteNodesEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditDeleteReferencesEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryAtTimeDeleteEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryDeleteEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventDeleteEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryEventUpdateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryRawModifyDeleteEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryUpdateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditHistoryValueUpdateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditNodeManagementEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditOpenSecureChannelEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditProgramTransitionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSecurityEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditSessionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateMethodEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUpdateStateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditUrlMismatchEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuditWriteUpdateEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AuthorizationServiceConfigurationType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisInformation"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AxisScaleEnumeration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseModelChangeEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseObjectType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BitFieldMaskDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Boolean"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetReaderTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerDataSetWriterTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerTransportQualityOfService"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfo"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BuildInfoType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Byte"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ByteString"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateExpirationAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupFolderType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CertificateUpdatedAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ComplexNumberType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConditionVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConfigurationVersionDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ConnectionTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilter"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContentFilterElement"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ContinuationPoint"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Counter"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#CubeItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldContentMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldFlags"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFolderType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetMetaDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetOrderingType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetReaderType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetToWriter"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetWriterType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDefinition"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDescriptionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeDictionaryType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeEncodingType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSchemaHeader"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataTypeSystemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataValue"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramConnectionTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Date"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateString"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DateTime"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Decimal"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DecimalString"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteNodesItem"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeleteReferencesItem"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DeviceFailureEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticInfo"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiagnosticsLevel"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DialogConditionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscoveryConfiguration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscrepancyAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DiscreteItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Double"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DoubleComplexNumberType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Duration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DurationString"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EUInformation"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ElementOperand"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointConfiguration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EndpointUrlListDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDefinition"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumField"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EnumValueType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Enumeration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventFilter"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventNotifierType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventQueueOverflowEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExceptionDeviationFormat"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveDeviationAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLevelAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveLimitStateMachineType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExclusiveRateOfChangeAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExpandedNodeId"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ExtensionFieldsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldMetaData"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FieldTargetDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileDirectoryType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileTransferStateMachineType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FileType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperand"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FilterOperator"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateMachineType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteStateVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FiniteTransitionVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Float"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FolderType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#FromState"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneralModelChangeEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#GeneratesEvent"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Guid"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasAlarmSuppressionGroup"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCause"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasChild"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasComponent"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasCondition"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetReader"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDataSetWriter"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffect"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectDisable"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectEnable"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectSuppressed"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEffectUnsuppressed"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEncoding"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasEventSource"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasFalseSubState"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasHistoricalConfiguration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasModellingRule"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasNotifier"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasOrderedComponent"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasProperty"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasPubSubConnection"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubStateMachine"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasSubtype"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTrueSubState"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HasTypeDefinition"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HierarchicalReferences"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HighlyManagedAlarmConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoricalDataConfigurationType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEvent"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryEventFieldList"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryServerCapabilitiesType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HistoryUpdateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#HttpsCertificateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityCriteriaType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IdentityMappingRuleType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Image"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageBMP"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageGIF"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImageJPG"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ImagePNG"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InitialStateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#InstrumentDiagnosticAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int16"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int32"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Int64"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Integer"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IntegerId"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IssuedIdentityToken"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetMessageContentMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetReaderMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetWriterMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonNetworkMessageContentMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialConfigurationType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialDeletedAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyCredentialUpdatedAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#KeyValuePair"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LimitAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LiteralOperand"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocaleId"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#LocalizedText"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MaintenanceConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MdnsDiscoveryConfiguration"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MessageSecurityMode"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModelChangeStructureDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ModellingRuleType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MonitoringFilter"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateDiscreteType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#MultiStateValueDiscreteType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NDimensionArrayItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespaceMetadataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamespacesType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NamingRuleType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkAddressUrlType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NetworkGroupDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeAttributesMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeClass"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NodeId"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveDeviationAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLevelAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveLimitAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonExclusiveRateOfChangeAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonHierarchicalReferences"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentNetworkRedundancyType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NonTransparentRedundancyType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NormalizedString"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Number"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#NumericRange"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OffNormalAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OpenFileMode"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OperationLimitsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSet"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OptionSetType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Organizes"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#OverrideValueHandling"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PerformUpdateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PermissionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProcessConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2DataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnostic2Type"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramDiagnosticType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramStateMachineType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgramTransitionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ProgressEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PropertyType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubCommunicationFailureEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConfigurationDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubConnectionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsConnectionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterClassification"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsCounterType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetReaderType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsDataSetWriterType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsReaderGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsRootType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubDiagnosticsWriterGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubKeyServiceType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubState"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubStatusType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PubSubTransportLimitsExceedEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishSubscribeType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataItemsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetSourceDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedDataSetType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedEventsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PublishedVariableDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#QualifiedName"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Range"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ReaderGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundancySupport"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RedundantServerDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#References"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshEndEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshRequiredEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RefreshStartEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RegisteredServer"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePath"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RelativePathElement"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleMappingRuleChangedAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RolePermissionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleSetType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RoleType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaMinApplicationCertificateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#RsaSha256ApplicationCertificateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SByte"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SafetyConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsArrayType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SamplingIntervalDiagnosticsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupFolderType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SecurityTokenRequestType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SelectionListType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SemanticChangeStructureDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerCapabilitiesType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerConfigurationType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsSummaryType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerDiagnosticsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerOnNetwork"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerRedundancyType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerState"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerStatusType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServerVendorCapabilityType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ServiceCounterDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionAuthenticationToken"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsArrayType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsObjectType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionDiagnosticsVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsArrayType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionSecurityDiagnosticsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SessionsDiagnosticsSummaryType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ShelvedStateMachineType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SignedSoftwareCertificate"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleAttributeOperand"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SimpleTypeDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateMachineType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StateVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatisticalConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusCode"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StatusResult"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#String"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Structure"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDefinition"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureDescription"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureField"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#StructureType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetMirrorType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscribedDataSetType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsArrayType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SubscriptionDiagnosticsType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemDiagnosticAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemOffNormalAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#SystemStatusChangeEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TargetVariablesType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TemporaryFileTransferType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TestingConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Time"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeString"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TimeZoneDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#ToState"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrainingConditionClassType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransitionVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TransparentRedundancyType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TripAlarmType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListMasks"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TrustListUpdatedAuditEventType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateDiscreteType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#TwoStateVariableType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UABinaryFileDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt16"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt32"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt64"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInteger"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetMessageContentMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpNetworkMessageContentMask"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Union"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserCredentialCertificateType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserIdentityToken"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserNameIdentityToken"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenPolicy"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UtcTime"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VendorServerInfoType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VersionTime"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportDataType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#X509IdentityToken"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XVType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XYArrayItemType"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XmlElement"/>
+        <ua-core:containsNode rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#YArrayItemType"/>
+        <ua-core:lastModified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-09T00:00:00.000Z</ua-core:lastModified>
+        <ua-core:modelUri rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://opcfoundation.org/UA/</ua-core:modelUri>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt16 -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt16">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldFlags"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#PermissionType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UInt16</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between 0 and 65535.</ua-core:description>
+        <ua-core:displayName>UInt16</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=5</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt32 -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt32">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessLevelExType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AccessRestrictionType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AttributeWriteMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Counter"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DataSetFieldContentMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#EventNotifierType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IntegerId"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonDataSetMessageContentMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonNetworkMessageContentMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetMessageContentMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpNetworkMessageContentMask"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VersionTime"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UInt32</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between 0 and 4,294,967,295.</ua-core:description>
+        <ua-core:displayName>UInt32</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=7</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt64 -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt64">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BitFieldMaskDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UInt64</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an integer between 0 and 18,446,744,073,709,551,615.</ua-core:description>
+        <ua-core:displayName>UInt64</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=9</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInteger -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInteger">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Byte"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt16"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt32"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UInt64"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UInteger</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that can have any unsigned integer DataType.</ua-core:description>
+        <ua-core:displayName>UInteger</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=28</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetMessageContentMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetMessageContentMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpDataSetMessageContentMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpDataSetMessageContentMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15646</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpDataSetReaderMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpDataSetReaderMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15653</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetReaderMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpDataSetReaderMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpDataSetReaderMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21116</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpDataSetWriterMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpDataSetWriterMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15652</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpDataSetWriterMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpDataSetWriterMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpDataSetWriterMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21111</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpNetworkMessageContentMask -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpNetworkMessageContentMask">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpNetworkMessageContentMask</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpNetworkMessageContentMask</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15642</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpWriterGroupMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpWriterGroupMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15645</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UadpWriterGroupMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UadpWriterGroupMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=21105</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Union -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#Union">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>Union</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>This abstract DataType is the base DataType for all union DataTypes.</ua-core:description>
+        <ua-core:displayName>Union</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12756</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserCredentialCertificateType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserCredentialCertificateType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UserCredentialCertificateType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>UserCredentialCertificateType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15181</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserIdentityToken -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserIdentityToken">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#AnonymousIdentityToken"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#IssuedIdentityToken"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserNameIdentityToken"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#X509IdentityToken"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UserIdentityToken</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for a user identity token.</ua-core:description>
+        <ua-core:displayName>UserIdentityToken</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=316</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserNameIdentityToken -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserNameIdentityToken">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UserNameIdentityToken</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A token representing a user identified by a user name and password.</ua-core:description>
+        <ua-core:displayName>UserNameIdentityToken</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=322</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenPolicy -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenPolicy">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UserTokenPolicy</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a user token that can be used with a server.</ua-core:description>
+        <ua-core:displayName>UserTokenPolicy</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=304</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UserTokenType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UserTokenType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>The possible user token types.</ua-core:description>
+        <ua-core:displayName>UserTokenType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=303</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UtcTime -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UtcTime">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>UtcTime</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A date/time value specified in Universal Coordinated Time (UTC).</ua-core:description>
+        <ua-core:displayName>UtcTime</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=294</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VendorServerInfoType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VendorServerInfoType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>VendorServerInfoType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A base type for vendor specific server information.</ua-core:description>
+        <ua-core:displayName>VendorServerInfoType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=2033</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VersionTime -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#VersionTime">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>VersionTime</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>VersionTime</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=20998</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>WriterGroupDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>WriterGroupDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=15480</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>WriterGroupMessageDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>WriterGroupMessageDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15616</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupMessageType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#JsonWriterGroupMessageType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#UadpWriterGroupMessageType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>WriterGroupMessageType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>WriterGroupMessageType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17998</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportDataType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportDataType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportDataType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>WriterGroupTransportDataType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>WriterGroupTransportDataType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=15611</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupTransportType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerConnectionTransportType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BrokerWriterGroupTransportType"/>
+        <OpcUaNodeSet2:hasSubtype rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#DatagramWriterGroupTransportType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>WriterGroupTransportType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>WriterGroupTransportType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</ua-core:isAbstract>
+        <ua-core:nodeId>i=17997</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#WriterGroupType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAObjectType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>WriterGroupType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>WriterGroupType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=17725</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#X509IdentityToken -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#X509IdentityToken">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>X509IdentityToken</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>A token representing a user identified by an X509 certificate.</ua-core:description>
+        <ua-core:displayName>X509IdentityToken</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=325</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XVType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XVType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>XVType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>XVType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12080</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XYArrayItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XYArrayItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XVType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:arrayDimensions>0</ua-core:arrayDimensions>
+        <ua-core:browseName>XYArrayItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>XYArrayItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12038</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XmlElement -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#XmlElement">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UADataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:browseName>XmlElement</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:description>Describes a value that is an XML element.</ua-core:description>
+        <ua-core:displayName>XmlElement</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=16</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#YArrayItemType -->
+
+    <owl:NamedIndividual rdf:about="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#YArrayItemType">
+        <rdf:type rdf:resource="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAVariableType"/>
+        <ua-core:hasDataType rdf:resource="http://www.hsu-ifa.de/kb/opcua/OpcUaNodeSet2.owl#BaseDataType"/>
+        <ua-core:accessRestrictions rdf:datatype="http://www.w3.org/2001/XMLSchema#unsignedByte">0</ua-core:accessRestrictions>
+        <ua-core:arrayDimensions>0</ua-core:arrayDimensions>
+        <ua-core:browseName>YArrayItemType</ua-core:browseName>
+        <ua-core:browseNamespace>http://opcfoundation.org/UA/</ua-core:browseNamespace>
+        <ua-core:displayName>YArrayItemType</ua-core:displayName>
+        <ua-core:isAbstract rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</ua-core:isAbstract>
+        <ua-core:nodeId>i=12029</ua-core:nodeId>
+        <ua-core:nodeNamespace>http://opcfoundation.org/UA/</ua-core:nodeNamespace>
+        <ua-core:valueRank rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</ua-core:valueRank>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://www.fortiss.org/kb/opcua/OpcUaCore.owl#UAEntity"/>
+            <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#MessageSecurityMode"/>
+            <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#SecurityPolicy"/>
+            <rdf:Description rdf:about="http://www.hsu-ifa.de/ontologies/OpcUa.owl#UAServer"/>
+        </owl:members>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.6.2018-09-06T00:27:41Z) https://github.com/owlcs/owlapi -->
+

--- a/OPC UA/readme.md
+++ b/OPC UA/readme.md
@@ -1,0 +1,6 @@
+#A simplified Ontology to describe OPC UA Servers and their nodeset
+*Disclaimer: Credit to fortiss and their OpcUaNodeset-Ontology (https://github.com/OntoUA/ua-nodeset-core-ont). This ontology is based on theirs we just edited a couple of things because we are using this ontology in an execution environment*
+
+Full documentation of the changes compared to the full OpcUaNodeset ontology coming soon...
+- moved inverse object properties under same super properties as the property they belong to
+- hierarchicaReferences was inverse to itself this is better done with setting it to be symmetric


### PR DESCRIPTION
The ontology is a simplified version of the full OpcUaNodeset.owl which can be found under [https://github.com/OntoUA/ua-nodeset-core-ont/blob/master/owl/OpcUaNodeSet2.owl](). 
Because we want to use this ontology at runtime, this ontology features a lot less individuals. Only individuals of types (e.g. of classes UADataType and UAReferenceType have been kept). It also comes with some minor improvements (e.g. moved inverse properties under the correct superclass)